### PR TITLE
Fix background of select fields when they have errors

### DIFF
--- a/css/form-style.css
+++ b/css/form-style.css
@@ -53,6 +53,10 @@ div.input-field{
   margin: 10px 0px;
 }
 
+.select2 .select2-selection {
+  border-radius: 2px;
+}
+
 button, input, select, textarea{
   font-family: inherit;
   font-size: 95%;
@@ -114,7 +118,7 @@ input[type='radio']{      /*increase the size of radio buttons*/
   margin: 15px;
 }
 
-.antigen label{
+.antigen label:not(.help-block) {
   display: inline-block;
   width: 8%;
 }
@@ -124,6 +128,11 @@ input[type='radio']{      /*increase the size of radio buttons*/
 .has-error{
   border: 1px solid #c51244;
   background-color: #fff0f4;
+}
+
+.select2.has-error .select2-selection {
+  background: transparent;
+  border: none;
 }
 
 .help-block{


### PR DESCRIPTION
fix #5 

I also used the opportunity to fix a label width bug.

Before:
![Screen Shot 2020-10-03 at 11 37 35](https://user-images.githubusercontent.com/51180770/94994343-5de82080-056d-11eb-95a2-4ce0a97100dd.png)


After:
![Screen Shot 2020-10-03 at 11 37 02](https://user-images.githubusercontent.com/51180770/94994346-64769800-056d-11eb-9094-af1d4692107d.png)
![Screen Shot 2020-10-03 at 11 34 13](https://user-images.githubusercontent.com/51180770/94994357-7a845880-056d-11eb-9538-c90f6e52e167.png)
